### PR TITLE
feature: Add max col letter config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tap_google_sheets/.vscode/settings.json
 test_configuration.py
 tap_target_commands.sh
 secrets/*
+
+.env

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You will need a Google developer project to use this tool. After [creating a pro
   - `credentials_file`: the path to a valid Google credentials file (Either an OAuth client secrets file or a Service Account key file)
   - `spreadsheet_id`: unique identifier for each spreadsheet in Google Drive
   - `start_date`: absolute minimum start date to check file modified
+  - `max_col_letter`: maximum column letter to check for data (default is automatically detected)
 
 ## Quick Start
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -1,0 +1,34 @@
+version: 1
+default_environment: prod
+environments:
+- name: prod
+plugins:
+  extractors:
+  - name: tap-google-sheets
+    namespace: tap-google-sheets
+    pip_url: -e .
+    executable: tap-google-sheets
+    capabilities:
+    - catalog
+    - discover
+    - state
+    settings:
+    - name: spreadsheet_id
+      label: Spreadsheet ID
+      description: Unique identifier for each spreadsheet in Google Drive
+    - name: credentials_file
+      label: Credential File
+      description: The path to a valid Google credentials file (Either an OAuth client
+        secrets file or a Service Account key file)
+    - name: start_date
+      kind: date_iso8601
+      label: Start Date
+      description: absolute minimum start date to check file modified
+    - name: max_col_letter
+      label: Max Column Letter
+      description: The maximum column letter to check for data
+  loaders:
+  - name: target-parquet
+    variant: automattic
+    pip_url: git+https://github.com/Automattic/target-parquet.git
+project_id: e5c303bb-4e0d-482f-a43b-066e65e9cf1b

--- a/tap_google_sheets/__init__.py
+++ b/tap_google_sheets/__init__.py
@@ -17,10 +17,10 @@ REQUIRED_CONFIG_KEYS = [
     'start_date'
 ]
 
-def do_discover(client, spreadsheet_id):
+def do_discover(client: GoogleClient, config: dict):
 
     LOGGER.info('Starting discover')
-    catalog = discover(client, spreadsheet_id)
+    catalog = discover(client, config)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 
@@ -37,10 +37,9 @@ def main():
             state = parsed_args.state
 
         config = parsed_args.config
-        spreadsheet_id = config.get('spreadsheet_id')
 
         if parsed_args.discover:
-            do_discover(client, spreadsheet_id)
+            do_discover(client, config)
         elif parsed_args.catalog:
             sync(client=client,
                  config=config,

--- a/tap_google_sheets/discover.py
+++ b/tap_google_sheets/discover.py
@@ -1,9 +1,11 @@
 from singer.catalog import Catalog, CatalogEntry, Schema
+
+from tap_google_sheets import GoogleClient
 from tap_google_sheets.schema import get_schemas, STREAMS
 
 
-def discover(client, spreadsheet_id):
-    schemas, field_metadata = get_schemas(client, spreadsheet_id)
+def discover(client: GoogleClient, config: dict):
+    schemas, field_metadata = get_schemas(client, config)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():

--- a/tap_google_sheets/sync.py
+++ b/tap_google_sheets/sync.py
@@ -424,7 +424,7 @@ def sync(client, config, catalog, state):
             sheet_id = sheet.get('properties', {}).get('sheetId')
 
             # GET sheet_metadata and columns
-            sheet_schema, columns = get_sheet_metadata(sheet, spreadsheet_id, client)
+            sheet_schema, columns = get_sheet_metadata(sheet, client, config)
             # LOGGER.info('sheet_schema: {}'.format(sheet_schema))
 
             # SKIP empty sheets (where sheet_schema and columns are None)

--- a/tests/unittest/test_currency_format.py
+++ b/tests/unittest/test_currency_format.py
@@ -60,7 +60,7 @@ class TestNullCellFormat(unittest.TestCase):
         sheet = SHEET
         expected_format = {"type": ["null", "number"]}
 
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         print(sheet_json_schema)
         returned_formats = sheet_json_schema["properties"]["Column1"]
 

--- a/tests/unittest/test_limit_max_col.py
+++ b/tests/unittest/test_limit_max_col.py
@@ -1,0 +1,137 @@
+import pytest
+
+from tap_google_sheets import schema
+
+cols = [
+         {
+             "columnIndex": 1,
+             "columnLetter": "A",
+             "columnName": "a",
+             "columnType": "numberType.INTEGER",
+             "columnSkipped": False
+         },
+         {
+             "columnIndex": 2,
+             "columnLetter": "B",
+             "columnName": "b",
+             "columnType": "numberType.INTEGER",
+             "columnSkipped": False
+         },
+         {
+             "columnIndex": 3,
+             "columnLetter": "C",
+             "columnName": "c",
+             "columnType": "numberType",
+             "columnSkipped": False
+         }
+     ]
+
+cols_schema = {'a': {'type': ['null', 'integer']},
+               'b': {'type': ['null', 'integer']},
+               'c': {'type': ['null', 'number']}}
+
+@pytest.mark.parametrize(
+    "max_col_letter,expected_cols,expected_schema_cols",
+    [
+        pytest.param("A", cols[:1], {k: v for k, v in cols_schema.items() if k in ('a',)}, id='test_limit_max_col_A'),
+        pytest.param("B", cols[:2], {k: v for k, v in cols_schema.items() if k in ('a', 'b',)}, id='test_limit_max_col_B'),
+        pytest.param("C", cols, cols_schema, id='test_limit_max_col_C'),
+        pytest.param("D", cols, cols_schema, id='test_limit_max_col_D'),
+        pytest.param(None, cols, cols_schema, id='test_limit_max_col_None')
+    ]
+)
+def test_limit_max_col(max_col_letter, expected_cols, expected_schema_cols):
+    """
+    Test when the config max col letter is set, the schema return the columns with the max col letter
+    """
+    sheet = {
+        "properties":{
+            "sheetId":1825500887,
+            "title":"Sheet11"
+        },
+        "data":[
+            {
+                "rowData":[
+                    {
+                    "values":[
+                        {
+                            "formattedValue":"a",
+                        },
+                        {
+                            "formattedValue":"b",
+                        },
+                        {
+                            "formattedValue":"c",
+                        }
+                    ]
+                    },
+                    {
+                    "values":[
+                        {
+                            "effectiveValue": {
+                                "numberValue": 1
+                            },
+                            "effectiveFormat": {
+                                "numberFormat": {
+                                    "type": "NUMBER",
+                                    "pattern": "0"
+                                }
+                            }
+                        },
+                        {
+                            "effectiveValue": {
+                                "numberValue": 2.0
+                            },
+                            "effectiveFormat": {
+                                "numberFormat": {
+                                    "type": "NUMBER",
+                                    "pattern": "0"
+                                }
+                            }
+                        },
+                        {
+                            "effectiveValue": {
+                                "numberValue": 3.1
+                            },
+                            "effectiveFormat": {
+                                "numberFormat": {
+                                    "type": "NUMBER",
+                                    "pattern": "0.0"
+                                }
+                            }
+                        }
+                    ]
+                    }
+                ]
+            }
+        ]
+    }
+    expected_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "__sdc_spreadsheet_id": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "__sdc_sheet_id": {
+                "type": [
+                    "null",
+                    "integer"
+                ]
+            },
+            "__sdc_row": {
+                "type": [
+                    "null",
+                    "integer"
+                ]
+            },
+            **expected_schema_cols
+        }
+    }
+    sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={'max_col_letter': max_col_letter})
+    assert expected_schema == sheet_json_schema
+    assert expected_cols == columns
+

--- a/tests/unittest/test_logger.py
+++ b/tests/unittest/test_logger.py
@@ -72,6 +72,6 @@ class TestLogger(unittest.TestCase):
         }
         # retrieve the sheet title from the `sheet_data`
         sheet_title = sheet_data.get('properties', {}).get('title')
-        sheet_schema, columns = schema.get_sheet_schema_columns(sheet_data)
+        sheet_schema, columns = schema.get_sheet_schema_columns(sheet_data, config={})
         # check if the logger is called with correct logger message
         mocked_logger.assert_called_with('SKIPPING THE SHEET AS HEADERS ROW IS EMPTY. SHEET: {}'.format(sheet_title))

--- a/tests/unittest/test_null_cell_format.py
+++ b/tests/unittest/test_null_cell_format.py
@@ -56,7 +56,7 @@ class TestNullCellFormat(unittest.TestCase):
             "format": "date-time"
         }
 
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         returned_formats = sheet_json_schema["properties"]["Column1"]
 
         # verify the returned schema has expected field types and format
@@ -78,7 +78,7 @@ class TestNullCellFormat(unittest.TestCase):
             "format": "date"
         }
 
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         returned_formats = sheet_json_schema["properties"]["Column1"]
 
         # verify the returned schema has expected field types and format
@@ -100,7 +100,7 @@ class TestNullCellFormat(unittest.TestCase):
             'format': 'time'
         }
 
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         returned_formats = sheet_json_schema["properties"]["Column1"]
 
         # verify the returned schema has expected field types and format
@@ -117,7 +117,7 @@ class TestNullCellFormat(unittest.TestCase):
 
         expected_format = {"type": ["null", "number"]}
 
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         returned_formats = sheet_json_schema["properties"]["Column1"]
 
         # verify returned schema has expected field types and format

--- a/tests/unittest/test_singer_decimal.py
+++ b/tests/unittest/test_singer_decimal.py
@@ -84,7 +84,7 @@ class TestUnsupportedFields(unittest.TestCase):
                 'b': {'type': ['null', 'number']},
             }
         }
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         self.assertEqual(sheet_json_schema, expected_schema) # test the schema is as expected
         self.assertEqual(columns, expected_columns) # test if the columns is as expected
 
@@ -204,7 +204,7 @@ class TestUnsupportedFields(unittest.TestCase):
                 'c': {'type': ['null', 'number']},
             }
         }
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         self.assertEqual(sheet_json_schema, expected_schema) # test the schema is as expected
         self.assertEqual(columns, expected_columns) # test if the columns is as expected
 

--- a/tests/unittest/test_unsupported_fields.py
+++ b/tests/unittest/test_unsupported_fields.py
@@ -83,6 +83,6 @@ class TestUnsupportedFields(unittest.TestCase):
                 }
             }
         }
-        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet)
+        sheet_json_schema, columns = schema.get_sheet_schema_columns(sheet, config={})
         self.assertEqual(sheet_json_schema, expected_schema) # test the schema is as expected
         self.assertEqual(columns, expected_columns) # test if the columns is as expected


### PR DESCRIPTION
# Description of change
This option can limit the columns to be extracted according to the column letter. It will extract all columns lower than or equal to the defined limit, if nothing is set, the default behavior of identifying the last col will be used.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
