### PR TITLE
Increase Backoff max time

### DIFF
--- a/tap_google_sheets/client.py
+++ b/tap_google_sheets/client.py
@@ -190,7 +190,7 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
                           (Server5xxError, ConnectionError, Server429Error),
                           max_tries=10,
                           jitter=backoff.random_jitter,
-                          max_time=300
+                          max_time=500
                           )
     @utils.ratelimit(60, 60)
     def request(self, endpoint=None, params={}, **kwargs):

--- a/tap_google_sheets/client.py
+++ b/tap_google_sheets/client.py
@@ -190,7 +190,7 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
                           (Server5xxError, ConnectionError, Server429Error),
                           max_tries=10,
                           jitter=backoff.random_jitter,
-                          max_time=500
+                          max_time=300
                           )
     @utils.ratelimit(60, 60)
     def request(self, endpoint=None, params={}, **kwargs):

--- a/tap_google_sheets/client.py
+++ b/tap_google_sheets/client.py
@@ -190,7 +190,7 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
                           (Server5xxError, ConnectionError, Server429Error),
                           max_tries=10,
                           jitter=backoff.random_jitter,
-                          max_time=64  # maximum_backoff in seconds (64 seconds)
+                          max_time=300
                           )
     @utils.ratelimit(60, 60)
     def request(self, endpoint=None, params={}, **kwargs):


### PR DESCRIPTION
# Description of change
The last attempt is too close to the number of requests reset per user/project (60 per minute), so this PR adds more time to allow attempts 8 (~120s) and 9 (~240s) to make sure that it will not reach the max time before the reset.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
